### PR TITLE
feat(backend): questions common or unique

### DIFF
--- a/backend/migrations/2023-02-08-081803_questions/down.sql
+++ b/backend/migrations/2023-02-08-081803_questions/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS questions
+    DROP COLUMN role_id;

--- a/backend/migrations/2023-02-08-081803_questions/up.sql
+++ b/backend/migrations/2023-02-08-081803_questions/up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE IF EXISTS questions
+    ADD COLUMN role_id INTEGER DEFAULT NULL;
+
+-- Make questions currently assigned to one role, uncommon
+UPDATE questions SET role_id=role_ids[1] WHERE array_length(role_ids, 1) = 1;
+
+-- No need to change questions currently assigned to multiple roles, as role_id is NULL by default, thus making them common
+
+ALTER TABLE IF EXISTS questions
+    DROP COLUMN role_ids;

--- a/backend/seed_data/src/seed.rs
+++ b/backend/seed_data/src/seed.rs
@@ -175,7 +175,8 @@ pub fn seed() {
     let question_one = NewQuestion {
         title: "What is the meaning of life?".to_string(),
         max_bytes: 100,
-        role_ids: vec![senior_mentor_role.id],
+        role_id: Option::from(senior_mentor_role.id),
+        // role_ids: vec![senior_mentor_role.id],
         required: false,
         description: Some("Please ensure to go into great detail!".to_string()),
     }
@@ -185,7 +186,7 @@ pub fn seed() {
     let question_two = NewQuestion {
         title: "Why do you want to be a Peer Mentor".to_string(),
         max_bytes: 300,
-        role_ids: vec![senior_mentor_role.id, mentor_role.id],
+        role_id: None,
         required: true,
         description: Some("Please explain why you would like to be a peer mentor!".to_string()),
     }

--- a/backend/server/src/campaigns.rs
+++ b/backend/server/src/campaigns.rs
@@ -171,7 +171,6 @@ pub async fn new(
                     return Err(JsonErr(CampaignError::UnableToCreate, Status::BadRequest));
                 }
             }
-
         }
 
         for question in new_questions {

--- a/backend/server/src/campaigns.rs
+++ b/backend/server/src/campaigns.rs
@@ -71,7 +71,7 @@ pub async fn update(
             .check()
             .or_else(|_| Err(JsonErr(CampaignError::Unauthorized, Status::Forbidden)))?;
 
-        Campaign::update(&conn, campaign_id, &update_campaign);
+        Campaign::update(conn, campaign_id, &update_campaign);
 
         Ok(Json(()))
     })
@@ -139,7 +139,7 @@ pub async fn new(
             .check()
             .or_else(|_| Err(JsonErr(CampaignError::Unauthorized, Status::Forbidden)))?;
 
-        let campaign = Campaign::create(&conn, &campaign).ok_or_else(|| {
+        let campaign = Campaign::create(conn, &campaign).ok_or_else(|| {
             eprintln!("Failed to create campaign for some reason: {:?}", campaign);
             JsonErr(CampaignError::UnableToCreate, Status::InternalServerError)
         })?;
@@ -155,7 +155,7 @@ pub async fn new(
                 max_available: role.max_available,
                 finalised: campaign.published,
             };
-            let inserted_role = new_role.insert(&conn).ok_or_else(|| {
+            let inserted_role = new_role.insert(conn).ok_or_else(|| {
                 eprintln!("Failed to create role for some reason: {:?}", new_role);
                 JsonErr(CampaignError::UnableToCreate, Status::InternalServerError)
             })?;
@@ -180,7 +180,7 @@ pub async fn new(
             if question.role_ids.len() == 0 {
                 return Err(JsonErr(CampaignError::InvalidInput, Status::BadRequest));
             }
-            question.insert(&conn).ok_or_else(|| {
+            question.insert(conn).ok_or_else(|| {
                 eprintln!("Failed to create question for some reason");
                 JsonErr(CampaignError::UnableToCreate, Status::InternalServerError)
             })?;
@@ -204,7 +204,7 @@ pub async fn delete_campaign(
             .check()
             .or_else(|_| Err(JsonErr(CampaignError::Unauthorized, Status::Forbidden)))?;
 
-        Campaign::delete_deep(&conn, campaign_id);
+        Campaign::delete_deep(conn, campaign_id);
 
         Ok(Json(()))
     })

--- a/backend/server/src/campaigns.rs
+++ b/backend/server/src/campaigns.rs
@@ -71,7 +71,7 @@ pub async fn update(
             .check()
             .or_else(|_| Err(JsonErr(CampaignError::Unauthorized, Status::Forbidden)))?;
 
-        Campaign::update(conn, campaign_id, &update_campaign);
+        Campaign::update(&conn, campaign_id, &update_campaign);
 
         Ok(Json(()))
     })
@@ -139,7 +139,7 @@ pub async fn new(
             .check()
             .or_else(|_| Err(JsonErr(CampaignError::Unauthorized, Status::Forbidden)))?;
 
-        let campaign = Campaign::create(conn, &campaign).ok_or_else(|| {
+        let campaign = Campaign::create(&conn, &campaign).ok_or_else(|| {
             eprintln!("Failed to create campaign for some reason: {:?}", campaign);
             JsonErr(CampaignError::UnableToCreate, Status::InternalServerError)
         })?;
@@ -155,7 +155,7 @@ pub async fn new(
                 max_available: role.max_available,
                 finalised: campaign.published,
             };
-            let inserted_role = new_role.insert(conn).ok_or_else(|| {
+            let inserted_role = new_role.insert(&conn).ok_or_else(|| {
                 eprintln!("Failed to create role for some reason: {:?}", new_role);
                 JsonErr(CampaignError::UnableToCreate, Status::InternalServerError)
             })?;
@@ -180,7 +180,7 @@ pub async fn new(
             if question.role_ids.len() == 0 {
                 return Err(JsonErr(CampaignError::InvalidInput, Status::BadRequest));
             }
-            question.insert(conn).ok_or_else(|| {
+            question.insert(&conn).ok_or_else(|| {
                 eprintln!("Failed to create question for some reason");
                 JsonErr(CampaignError::UnableToCreate, Status::InternalServerError)
             })?;
@@ -204,7 +204,7 @@ pub async fn delete_campaign(
             .check()
             .or_else(|_| Err(JsonErr(CampaignError::Unauthorized, Status::Forbidden)))?;
 
-        Campaign::delete_deep(conn, campaign_id);
+        Campaign::delete_deep(&conn, campaign_id);
 
         Ok(Json(()))
     })

--- a/backend/server/src/database/models.rs
+++ b/backend/server/src/database/models.rs
@@ -960,8 +960,7 @@ pub struct UpdateQuestionInput {
 
 impl Question {
     pub fn get_first_role(&self) -> i32 {
-        self
-            .role_id
+        self.role_id
             .expect("Question should be for at least one role")
     }
 
@@ -980,8 +979,7 @@ impl Question {
         Some(())
     }
 
-    pub fn
-    get_all_from_role_id(conn: &PgConnection, role_id_val: i32) -> Vec<Question> {
+    pub fn get_all_from_role_id(conn: &PgConnection, role_id_val: i32) -> Vec<Question> {
         diesel::sql_query(&format!(
             "select * from questions where {} = role_id or role_id is null",
             role_id_val

--- a/backend/server/src/database/schema.rs
+++ b/backend/server/src/database/schema.rs
@@ -106,7 +106,7 @@ table! {
 
     questions (id) {
         id -> Int4,
-        role_ids -> Array<Int4>,
+        role_id -> Nullable<Int4>,
         title -> Text,
         description -> Nullable<Text>,
         max_bytes -> Int4,


### PR DESCRIPTION
* questions table now has `role_id` field with (nullable) integer, instead of array - new migration for this.
* null `role_id` for common question.
* requires new field `common_question` in `question` objects in JSON request for `POST /` for campaigns request.