### PR TITLE
fix(backend): Add dotenvy to server and prisma

### DIFF
--- a/backend/prisma-cli/Cargo.toml
+++ b/backend/prisma-cli/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 prisma-client-rust-cli = { git = "https://github.com/Brendonovich/prisma-client-rust", tag = "0.6.10", features = [
     "postgresql",
 ] }
+dotenvy = "0.15.7"
 
 [alias]
 prisma = "run --bin prisma-cli --"

--- a/backend/prisma-cli/src/main.rs
+++ b/backend/prisma-cli/src/main.rs
@@ -1,3 +1,4 @@
 fn main() {
+    dotenvy::dotenv().unwrap();
     prisma_client_rust_cli::run();
 }

--- a/backend/server/Cargo.toml
+++ b/backend/server/Cargo.toml
@@ -23,3 +23,4 @@ log = "0.4.20"
 uuid = { version = "1.5.0", features = ["serde", "v4"] }
 rs-snowflake = "0.6.0"
 jsonwebtoken = "9.1.0"
+dotenvy = "0.15.7"

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -1,4 +1,5 @@
 use std::env;
+use anyhow::Result;
 use axum::{routing::get, Router};
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use snowflake::SnowflakeIdGenerator;
@@ -9,7 +10,9 @@ mod models;
 mod service;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<()> {
+    dotenvy::dotenv()?;
+
     // Initialise DB connection
     let db_url = env::var("DATABASE_URL")
         .expect("Error getting DATABASE_URL")
@@ -49,4 +52,6 @@ async fn main() {
         .serve(app.into_make_service())
         .await
         .unwrap();
+
+    Ok(())
 }


### PR DESCRIPTION
Environment variables can now be declared in a `.env` file in the `backend` directory. Variables will be common to `prisma-cli` and `server`.