### PR TITLE
hotfix: allow for questions to be edited post publish

### DIFF
--- a/frontend-nextjs/src/app/[lang]/dashboard/organisation/[orgId]/campaigns/[campaignId]/campaign-details.tsx
+++ b/frontend-nextjs/src/app/[lang]/dashboard/organisation/[orgId]/campaigns/[campaignId]/campaign-details.tsx
@@ -217,7 +217,7 @@ export default function CampaignDetails({ campaignId, orgId, dict }: { campaignI
                 {/* <Button variant="outline" className="cursor-pointer w-full justify-center sm:w-auto">
                   <Trash className="w-4 h-4" /> {dict.dashboard.actions.delete}
                 </Button> */}
-                {!campaign?.published && (
+                {/* {!campaign?.published && ( */}
                   <>
                     <ButtonGroup className="w-full sm:w-auto flex-col sm:flex-row gap-2 sm:gap-0 [&>*]:w-full sm:[&>*]:w-auto">
                       <Link href={`/dashboard/organisation/${orgId}/campaigns/${campaignId}/questions`} className="w-full sm:w-auto">
@@ -234,7 +234,7 @@ export default function CampaignDetails({ campaignId, orgId, dict }: { campaignI
                       />
                     </ButtonGroup>
                   </>
-                )}
+                {/* )} */}
               </>
             )}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admins can now access campaign question-management and publishing controls even after a campaign has been published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->